### PR TITLE
Refresh most relevant packages in fun statistics

### DIFF
--- a/app/src/config/fun.json
+++ b/app/src/config/fun.json
@@ -12,6 +12,7 @@
     "vi",
     "vim",
     "gedit",
+    "neovim",
     "kate",
     "emacs",
     "mousepad",

--- a/app/src/config/fun.json
+++ b/app/src/config/fun.json
@@ -77,7 +77,18 @@
     "ruby",
     "nodejs",
     "java-environment-common",
-    "php",
-    "rust"
+    "php"
+  ],
+  "System Languages": [
+    "clang",
+    "gcc",
+    "ghc",
+    "go",
+    "nim",
+    "ocaml",
+    "rust",
+    "rustup",
+    "vala",
+    "zig"
   ]
 }

--- a/app/src/config/fun.json
+++ b/app/src/config/fun.json
@@ -5,6 +5,9 @@
     "google-chrome",
     "epiphany",
     "konqueror",
+    "tor-browser",
+    "opera",
+    "vivaldi",
     "midori"
   ],
   "Editors": [

--- a/app/src/config/fun.json
+++ b/app/src/config/fun.json
@@ -5,6 +5,7 @@
     "google-chrome",
     "epiphany",
     "konqueror",
+    "brave-bin",
     "tor-browser",
     "opera",
     "vivaldi",

--- a/app/src/config/fun.json
+++ b/app/src/config/fun.json
@@ -43,6 +43,7 @@
     "caja"
   ],
   "Window Managers": [
+    "i3-gaps",
     "openbox",
     "i3-wm",
     "awesome",

--- a/app/src/config/fun.json
+++ b/app/src/config/fun.json
@@ -24,7 +24,8 @@
     "kwrite",
     "atom",
     "geany",
-    "leafpad"
+    "leafpad",
+    "sublime"
   ],
   "Desktop Environments": [
     "plasma-workspace",

--- a/app/src/config/fun.json
+++ b/app/src/config/fun.json
@@ -68,6 +68,7 @@
     "ruby",
     "nodejs",
     "java-environment-common",
-    "php"
+    "php",
+    "rust"
   ]
 }

--- a/app/src/config/fun.json
+++ b/app/src/config/fun.json
@@ -51,7 +51,7 @@
     "dash",
     "tcsh"
   ],
-  "Xorg GPU drivers": [
+  "Xorg GPU Drivers": [
     "xf86-video-intel",
     "nvidia-utils",
     "xf86-video-amdgpu",
@@ -59,7 +59,7 @@
     "xf86-video-ati",
     "nvidia-390xx-utils"
   ],
-  "Runtime Environment": [
+  "Runtime Environments": [
     "perl",
     "bash",
     "python",

--- a/app/src/config/fun.json
+++ b/app/src/config/fun.json
@@ -19,8 +19,10 @@
     "neovim",
     "kate",
     "emacs",
+    "code",
     "mousepad",
     "kwrite",
+    "atom",
     "geany",
     "leafpad"
   ],
@@ -62,7 +64,9 @@
     "nvidia-utils",
     "xf86-video-amdgpu",
     "xf86-video-nouveau",
-    "xf86-video-ati"
+    "xf86-video-ati",
+    "xf86-video-vmware",
+    "xf86-video-openchrome"
   ],
   "Runtime Environments": [
     "perl",

--- a/app/src/config/fun.json
+++ b/app/src/config/fun.json
@@ -62,8 +62,7 @@
     "nvidia-utils",
     "xf86-video-amdgpu",
     "xf86-video-nouveau",
-    "xf86-video-ati",
-    "nvidia-390xx-utils"
+    "xf86-video-ati"
   ],
   "Runtime Environments": [
     "perl",


### PR DESCRIPTION
Happy to adjust these commits if there are changes that are more or less welcome. Note there are some outliers here like `brave-bin` which is the most used Brave package but obnoxious to have as a name in the list. Another is whether the VESA video driver belongs in the list. I think it used to be a fallback package that most systems had, but is still used for cases like VirtualBox. Not including it makes VMWare appear to have an outsized share. Really `i3-gaps` and `i3-wm` should be merged, but that functionality isn't available. If it was I would probably merge `vi` and `vim` too since it's impossible to get the latter without the former.