### PR TITLE
Use the geo.mirror.pkgbuild.com mirror

### DIFF
--- a/api/src/Controller/PostPackageListController.php
+++ b/api/src/Controller/PostPackageListController.php
@@ -69,7 +69,7 @@ class PostPackageListController extends AbstractController
                                 property: 'mirror',
                                 description: 'Package mirror',
                                 type: 'string',
-                                example: 'https://mirror.pkgbuild.com/'
+                                example: 'https://geo.mirror.pkgbuild.com/'
                             ),
                             new OA\Property(
                                 property: 'packages',

--- a/api/tests/Controller/__snapshots__/SmokeTest__testApiDoc__1.json
+++ b/api/tests/Controller/__snapshots__/SmokeTest__testApiDoc__1.json
@@ -246,7 +246,7 @@
                                             "mirror": {
                                                 "description": "Package mirror",
                                                 "type": "string",
-                                                "example": "https:\/\/mirror.pkgbuild.com\/"
+                                                "example": "https:\/\/geo.mirror.pkgbuild.com\/"
                                             },
                                             "packages": {
                                                 "description": "List of package names",


### PR DESCRIPTION
geo.mirror.pkgbuild.com is a GeoDNS mirror that points to sponsored mirrors.

This avoids the usage of Arch's infrastructure (mirror.pkgbuild.com) for large downloads. See https://gitlab.archlinux.org/archlinux/infrastructure/-/merge_requests/522 for details.