### PR TITLE
Add budgie-desktop and micro to fun.json

### DIFF
--- a/app/src/config/fun.json
+++ b/app/src/config/fun.json
@@ -23,7 +23,8 @@
     "kwrite",
     "atom",
     "geany",
-    "leafpad"
+    "leafpad",
+    "micro"
   ],
   "Desktop Environments": [
     "plasma-workspace",
@@ -31,7 +32,8 @@
     "xfdesktop",
     "cinnamon",
     "lxde-common",
-    "mate-panel"
+    "mate-panel",
+    "budgie-desktop"
   ],
   "File Managers": [
     "thunar",


### PR DESCRIPTION
Micro is at 4.78% among the Editors category, more popular than both leafpad and atom, and budgie-desktop is at 1.05% among the Desktop Environments category.