### PR TITLE
Add more entries to fun (and sort the file)

### DIFF
--- a/app/src/config/fun.json
+++ b/app/src/config/fun.json
@@ -15,15 +15,18 @@
     "emacs",
     "geany",
     "gedit",
+    "helix",
     "kakoune",
     "kate",
+    "gnome-text-editor",
     "leafpad",
     "micro",
     "mousepad",
     "nano",
     "neovim",
     "vi",
-    "vim"
+    "vim",
+    "zed"
   ],
   "Desktop Environments": [
     "budgie-desktop",
@@ -47,6 +50,7 @@
   "Window Managers": [
     "awesome",
     "fluxbox",
+    "hyprland",
     "i3-wm",
     "openbox",
     "sway"
@@ -55,11 +59,13 @@
     "bash",
     "dash",
     "fish",
+    "nushell",
     "tcsh",
     "zsh"
   ],
   "Terminal Emulators": [
     "alacritty",
+    "gnome-console",
     "gnome-terminal",
     "konsole",
     "terminator",
@@ -78,6 +84,7 @@
   ],
   "Runtime Environments": [
     "bash",
+    "deno",
     "erlang-nox",
     "java-environment-common",
     "lua",

--- a/app/src/config/fun.json
+++ b/app/src/config/fun.json
@@ -1,62 +1,62 @@
 {
   "Browsers": [
-    "firefox",
+    "brave-bin",
     "chromium",
-    "google-chrome",
     "epiphany",
+    "firefox",
+    "google-chrome",
     "konqueror",
-    "torbrowser-launcher",
     "opera",
-    "vivaldi",
-    "brave-bin"
+    "torbrowser-launcher",
+    "vivaldi"
   ],
   "Editors": [
-    "nano",
-    "vi",
-    "vim",
-    "gedit",
-    "neovim",
-    "kate",
-    "emacs",
     "code",
-    "mousepad",
+    "emacs",
     "geany",
+    "gedit",
+    "kakoune",
+    "kate",
     "leafpad",
     "micro",
-    "kakoune"
+    "mousepad",
+    "nano",
+    "neovim",
+    "vi",
+    "vim"
   ],
   "Desktop Environments": [
-    "plasma-workspace",
-    "gnome-shell",
-    "xfdesktop",
+    "budgie-desktop",
     "cinnamon",
+    "gnome-shell",
     "lxde-common",
     "mate-panel",
-    "budgie-desktop"
+    "plasma-workspace",
+    "xfdesktop"
   ],
   "File Managers": [
-    "thunar",
-    "nautilus",
+    "caja",
     "dolphin",
+    "konqueror",
     "mc",
+    "nautilus",
     "nemo",
     "pcmanfm",
-    "konqueror",
-    "caja"
+    "thunar"
   ],
   "Window Managers": [
-    "openbox",
-    "i3-wm",
     "awesome",
-    "sway",
-    "fluxbox"
+    "fluxbox",
+    "i3-wm",
+    "openbox",
+    "sway"
   ],
   "Shells": [
     "bash",
-    "zsh",
-    "fish",
     "dash",
-    "tcsh"
+    "fish",
+    "tcsh",
+    "zsh"
   ],
   "Terminal Emulators": [
     "alacritty",
@@ -68,24 +68,24 @@
     "yakuake"
   ],
   "Xorg GPU Drivers": [
-    "xf86-video-intel",
     "nvidia-utils",
     "xf86-video-amdgpu",
-    "xf86-video-nouveau",
     "xf86-video-ati",
-    "xf86-video-vmware",
-    "xf86-video-openchrome"
+    "xf86-video-intel",
+    "xf86-video-nouveau",
+    "xf86-video-openchrome",
+    "xf86-video-vmware"
   ],
   "Runtime Environments": [
-    "perl",
     "bash",
-    "python",
-    "lua",
-    "ruby",
-    "nodejs",
+    "erlang-nox",
     "java-environment-common",
+    "lua",
+    "nodejs",
+    "perl",
     "php",
-    "erlang-nox"
+    "python",
+    "ruby"
   ],
   "System Languages": [
     "clang",


### PR DESCRIPTION
See the second commit on its own to see a clear diff what was added.

https://pkgstats.archlinux.de/compare/packages#packages=deno,gnome-console,gnome-text-editor,helix,hyprland,nushell,zed

I added only things from the official repos. All of them are used by me or seem interesting to me. For example [gedit being slowly replaced by gnome-text-editor and gnome-terminal being slowly replaced by gnome-console](https://pkgstats.archlinux.de/compare/packages#packages=gedit,gnome-console,gnome-terminal,gnome-text-editor).

Seeing #139: deno, nushell and zed are below 5%, the others are higher. All of them are rising.