### PR TITLE
143: preseve package comparison information

### DIFF
--- a/app/src/composables/useFetchPackagesPopularity.js
+++ b/app/src/composables/useFetchPackagesPopularity.js
@@ -33,7 +33,7 @@ export const useFetchPackagesPopularity = (pkgs) => {
       isFetching.value = false
     })
 
-  watch(() => pkgs, fetchPkgData, { immediate: true })
+  watch(pkgs, fetchPkgData, { immediate: true })
 
   return {
     data,

--- a/app/src/composables/useFetchPackagesPopularity.js
+++ b/app/src/composables/useFetchPackagesPopularity.js
@@ -1,30 +1,39 @@
-import { ref, unref } from 'vue'
+import { ref, unref, watch } from 'vue'
 import { useFetchPackagePopularity } from './useFetchPackagePopularity'
 
-const sortPackagesByPopularity = packagePopularities => packagePopularities.sort((a, b) => Math.sign(b.popularity - a.popularity))
+const sortPackagesByPopularity = (packagePopularities) =>
+  packagePopularities.sort((a, b) => Math.sign(b.popularity - a.popularity))
 
 /**
  * @param {ref<array>} pkgs
  * @returns {Promise<any>}
  */
 export const useFetchPackagesPopularity = (pkgs) => {
-  const data = ref(unref(pkgs).map(pkg => ({ name: pkg, popularity: 0.0 })))
+  const data = ref(unref(pkgs).map((pkg) => ({ name: pkg, popularity: 0.0 })))
   const isFinished = ref(false)
   const isFetching = ref(true)
   const error = ref([])
 
-  Promise.all(unref(pkgs).map(pkg => useFetchPackagePopularity(pkg)))
-    .then(results => {
-      data.value = sortPackagesByPopularity(results.map(result => unref(result.data)))
-      error.value = results.map(result => unref(result.error)).filter(error => error)
+  const fetchPkgData = () => Promise.all(
+    unref(pkgs).map((pkg) => useFetchPackagePopularity(pkg))
+  )
+    .then((results) => {
+      data.value = sortPackagesByPopularity(
+        results.map((result) => unref(result.data))
+      )
+      error.value = results
+        .map((result) => unref(result.error))
+        .filter((error) => error)
       isFinished.value = true
     })
-    .catch(e => {
+    .catch((e) => {
       error.value.push(e.toString())
     })
     .finally(() => {
       isFetching.value = false
     })
+
+  watch(() => pkgs, fetchPkgData, { immediate: true })
 
   return {
     data,

--- a/app/src/composables/useFetchPackagesPopularity.js
+++ b/app/src/composables/useFetchPackagesPopularity.js
@@ -4,7 +4,7 @@ import { useFetchPackagePopularity } from './useFetchPackagePopularity'
 const sortPackagesByPopularity = packagePopularities => packagePopularities.sort((a, b) => Math.sign(b.popularity - a.popularity))
 
 /**
- * @param {array<string>} pkgs
+ * @param {ref<array>} pkgs
  * @returns {Promise<any>}
  */
 export const useFetchPackagesPopularity = (pkgs) => {

--- a/app/src/router.js
+++ b/app/src/router.js
@@ -14,7 +14,7 @@ export default createRouter({
     { path: '/fun', name: 'fun', component: () => import(/* webpackChunkName: "fun" */ './views/Fun') },
     { path: '/impressum', name: 'impressum', component: () => import(/* webpackChunkName: "legal" */ './views/Impressum') },
     { path: '/packages/:package', name: 'package', component: () => import(/* webpackChunkName: "package-chart" */ './views/Package') },
-    { path: '/packages', name: 'packages', component: Packages, meta: { preselectedPackages: null } },
+    { path: '/packages', name: 'packages', component: Packages },
     { path: '/privacy-policy', name: 'privacy-policy', component: () => import(/* webpackChunkName: "legal" */ './views/PrivacyPolicy') },
     { path: '/', name: 'start', component: Start },
     { path: '/api/doc', name: 'api-doc', component: () => import(/* webpackChunkName: "api-doc" */ './views/ApiDoc') },

--- a/app/src/router.js
+++ b/app/src/router.js
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import { ref } from 'vue'
 import Packages from './views/Packages'
 import Start from './views/Start'
 import NotFound from './views/NotFound'
@@ -14,7 +15,7 @@ export default createRouter({
     { path: '/fun', name: 'fun', component: () => import(/* webpackChunkName: "fun" */ './views/Fun') },
     { path: '/impressum', name: 'impressum', component: () => import(/* webpackChunkName: "legal" */ './views/Impressum') },
     { path: '/packages/:package', name: 'package', component: () => import(/* webpackChunkName: "package-chart" */ './views/Package') },
-    { path: '/packages', name: 'packages', component: Packages },
+    { path: '/packages', name: 'packages', component: Packages, meta: { preselectedPackages: ref|null } },
     { path: '/privacy-policy', name: 'privacy-policy', component: () => import(/* webpackChunkName: "legal" */ './views/PrivacyPolicy') },
     { path: '/', name: 'start', component: Start },
     { path: '/api/doc', name: 'api-doc', component: () => import(/* webpackChunkName: "api-doc" */ './views/ApiDoc') },

--- a/app/src/router.js
+++ b/app/src/router.js
@@ -1,5 +1,4 @@
 import { createRouter, createWebHistory } from 'vue-router'
-import { ref } from 'vue'
 import Packages from './views/Packages'
 import Start from './views/Start'
 import NotFound from './views/NotFound'
@@ -15,7 +14,7 @@ export default createRouter({
     { path: '/fun', name: 'fun', component: () => import(/* webpackChunkName: "fun" */ './views/Fun') },
     { path: '/impressum', name: 'impressum', component: () => import(/* webpackChunkName: "legal" */ './views/Impressum') },
     { path: '/packages/:package', name: 'package', component: () => import(/* webpackChunkName: "package-chart" */ './views/Package') },
-    { path: '/packages', name: 'packages', component: Packages, meta: { preselectedPackages: ref|null } },
+    { path: '/packages', name: 'packages', component: Packages, meta: { preselectedPackages: null } },
     { path: '/privacy-policy', name: 'privacy-policy', component: () => import(/* webpackChunkName: "legal" */ './views/PrivacyPolicy') },
     { path: '/', name: 'start', component: Start },
     { path: '/api/doc', name: 'api-doc', component: () => import(/* webpackChunkName: "api-doc" */ './views/ApiDoc') },

--- a/app/src/views/Compare.vue
+++ b/app/src/views/Compare.vue
@@ -2,7 +2,10 @@
   <div class="container" role="main">
     <h1 class="mb-3">Compare Packages</h1>
     <p class="mb-3">Relative usage of packages</p>
-    <package-chart :limit="0" v-if="packages.length > 0" :packages="packages" :start-month="0"></package-chart>
+    <div  v-if="packages.length > 0">
+      <package-chart :limit="0" :packages="packages" :start-month="0" class="mb-4"></package-chart>
+      <router-link data-test-id="edit-selection-cta" class="btn btn-primary" :to="{name: 'packages', query: { compare: compareQuery} }">Edit selection</router-link>
+    </div>
     <div v-else class="alert alert-danger" role="alert">
       <h4 class="alert-heading">No packages defined</h4>
       <p>Provide at least one package name to compare</p>
@@ -28,6 +31,8 @@ const packages = computed(() => {
   return [...new Set(tempPackages)].sort().slice(0, 10)
 }
 )
+
+const compareQuery = computed(() => packages.value.join(','))
 
 const unwatch = watch(packages, () => {
   const canonicalHash = '#packages=' + packages.value.join(',')

--- a/app/src/views/Packages.vue
+++ b/app/src/views/Packages.vue
@@ -116,8 +116,8 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, ref } from 'vue'
-import { useRoute } from 'vue-router'
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { useIntersectionObserver } from '@vueuse/core'
 import { useHead } from '@vueuse/head'
 import { useRouteHash, useRouteQuery } from '@vueuse/router'
@@ -126,6 +126,23 @@ import { useFetchPackageList } from '../composables/useFetchPackageList'
 import trash from 'bootstrap-icons/icons/trash.svg?raw'
 import plus from 'bootstrap-icons/icons/plus-lg.svg?raw'
 
+const route = useRoute()
+const router = useRouter()
+
+router.beforeEach((to, from) => {
+  if (from.name === "compare") {
+    console.log(from)
+    const comparedPackageNames = from.hash.split('=')[1].split(',')
+    console.log(comparedPackageNames)
+
+
+    // TODO: fetch package info for names
+    // and pass data to page
+    return {name: 'Packages', data: {"comparedPackageNames": comparedPackageNames}}
+  }
+})
+
+// @Todo: how does it work with a hash? why not a questionmark?
 const query = useRouteQuery('query', useRouteHash('').value.replace(/^#query=/, ''))
 const offset = ref(0)
 const limit = ref(60)

--- a/app/src/views/Packages.vue
+++ b/app/src/views/Packages.vue
@@ -52,10 +52,10 @@
             You can only compare up to 10 packages.
         </div>
       </div>
-<!--      <div v-else class="mb-2">-->
-<!--        No packages selected. Use the search below to add packages-->
-<!--        and allow the generation of a comparison graph over time.-->
-<!--      </div>-->
+      <div v-else class="mb-2">
+        No packages selected. Use the search below to add packages
+        and allow the generation of a comparison graph over time.
+      </div>
     </div>
 
     <loading-spinner v-if="isFetching2"></loading-spinner>

--- a/app/src/views/Packages.vue
+++ b/app/src/views/Packages.vue
@@ -3,7 +3,7 @@
     <h1 class="mb-4">Package statistics & comparison</h1>
 
     <h2>Package comparison</h2>
-    <div v-if="isFinished2 && !error2" class="mb-4">
+    <div v-if="isFinished2 && error2.length === 0" class="mb-4">
       <div class="mb-2" v-if="selectedPackages.length > 0">
         <table class="table table-striped table-borderless table-sm">
           <thead>
@@ -59,7 +59,6 @@
     </div>
 
     <loading-spinner v-if="isFetching2"></loading-spinner>
-    <div role="alert" class="alert alert-danger" v-if="error2">{{ error2 }}</div>
 
     <h2>Package Search</h2>
     <div class="input-group mb-4">
@@ -135,27 +134,23 @@ const offset = ref(0)
 const limit = ref(60)
 
 const compare = useRouteQuery('compare', '')
-const selectedPackageNames = computed(() => compare.value.split(','))
+const selectedPackageNames = computed(() => compare.value ? compare.value.split(',') : [])
 
-const { isFinished2, isFetching2, selectedPackages, error2 } = useFetchPackagesPopularity(selectedPackageNames)
+const { isFinished: isFinished2, isFetching: isFetching2, data: selectedPackages, error: error2 } = useFetchPackagesPopularity(selectedPackageNames)
 
 const isPackageSelected = (pkg) => selectedPackages.value.map(selectedPackage => selectedPackage.name).includes(pkg.name)
 
 const togglePackageSelected = (pkg) => {
-  if (selectedPackages.value.length > 0) {
-    if (isPackageSelected(pkg)) {
-      selectedPackages.value = selectedPackages.value.filter((selectedPkg) => selectedPkg.name !== pkg.name)
-      compare.value = compare.value.split(',').filter((pkgName) => pkg.name !== pkgName).join(',')
-    } else {
-      selectedPackages.value.push(pkg)
-      compare.value = compare.value + ',' + pkg.name
-    }
+  const pkgIndex = selectedPackageNames.value.indexOf(pkg.name)
+  if (pkgIndex > -1) {
+    // Remove element as computed array is readonly
+    selectedPackageNames.value.splice(pkgIndex, 1)
   } else {
-    selectedPackages.value.push(pkg)
-    compare.value = compare.value + pkg.name
+    selectedPackageNames.value.push(pkg.name)
   }
-}
 
+  compare.value = [...new Set(selectedPackageNames.value)].sort().slice(0, 10).join(',')
+}
 
 const { isFinished, isFetching, data, error } = useFetchPackageList(query, offset, limit)
 

--- a/app/src/views/Packages.vue
+++ b/app/src/views/Packages.vue
@@ -123,6 +123,7 @@ import { useHead } from '@vueuse/head'
 import { useRouteHash, useRouteQuery } from '@vueuse/router'
 import LoadingSpinner from '../components/LoadingSpinner'
 import { useFetchPackageList } from '../composables/useFetchPackageList'
+import { useFetchPackagePopularity } from '../composables/useFetchPackagePopularity'
 import trash from 'bootstrap-icons/icons/trash.svg?raw'
 import plus from 'bootstrap-icons/icons/plus-lg.svg?raw'
 
@@ -133,12 +134,14 @@ router.beforeEach((to, from) => {
   if (from.name === "compare") {
     console.log(from)
     const comparedPackageNames = from.hash.split('=')[1].split(',')
-    console.log(comparedPackageNames)
-
-
-    // TODO: fetch package info for names
-    // and pass data to page
-    return {name: 'Packages', data: {"comparedPackageNames": comparedPackageNames}}
+    //console.log(comparedPackageNames)
+    let preselectedPackages = ref([])
+    comparedPackageNames.forEach((pkgName) => {
+      const { isFinished, isFetching, data, error } = useFetchPackagePopularity(pkgName)
+      preselectedPackages.value.push(data.value)
+    })
+    console.log(preselectedPackages.value)
+    return true
   }
 })
 

--- a/app/src/views/Packages.vue
+++ b/app/src/views/Packages.vue
@@ -134,8 +134,8 @@ const offset = ref(0)
 const limit = ref(60)
 
 const compare = useRouteQuery('compare', '')
-// remove duplicates if the user enters packages in the url directly
 const tmp = compare.value.split(',').filter(value => value.match(/^[a-zA-Z0-9][a-zA-Z0-9@:.+_-]+$/))
+// remove duplicates if the user enters packages in the url directly
 compare.value = [...new Set(tmp)].sort().slice(0, 10).join(',')
 
 const selectedPackageNames = computed(() => {

--- a/app/src/views/Packages.vue
+++ b/app/src/views/Packages.vue
@@ -28,8 +28,8 @@
               </div>
             </td>
             <td class="align-middle">
-              <button data-test="toggle-pkg-in-comparison-table" class="d-flex btn w-100 p-0 b-none" @click="togglePackageSelected(pkg)">
-                <template v-if="isPackageSelected(pkg)">
+              <button data-test="toggle-pkg-in-comparison-table" class="d-flex btn w-100 p-0 b-none" @click="togglePackageSelected(pkg.name)">
+                <template v-if="isPackageSelected(pkg.name)">
                   <span v-html="trash" class="d-inline-flex text-primary justify-content-center w-100"></span>
                 </template>
                 <template v-else>
@@ -92,8 +92,8 @@
             </div>
           </td>
           <td class="align-middle">
-            <button data-test="toggle-pkg-in-popularity-table" class="d-flex btn w-100 p-0 b-none" @click="togglePackageSelected(pkg)">
-              <template v-if="isPackageSelected(pkg)">
+            <button data-test="toggle-pkg-in-popularity-table" class="d-flex btn w-100 p-0 b-none" @click="togglePackageSelected(pkg.name)">
+              <template v-if="isPackageSelected(pkg.name)">
                 <span v-html="trash" class="text-primary d-inline-flex justify-content-center w-100"></span>
               </template>
               <template v-else>
@@ -138,15 +138,15 @@ const selectedPackageNames = computed(() => compare.value ? compare.value.split(
 
 const { isFinished: isFinished2, isFetching: isFetching2, data: selectedPackages, error: error2 } = useFetchPackagesPopularity(selectedPackageNames)
 
-const isPackageSelected = (pkg) => selectedPackages.value.map(selectedPackage => selectedPackage.name).includes(pkg.name)
+const isPackageSelected = (pkgName) => selectedPackageNames.value.includes(pkgName)
 
-const togglePackageSelected = (pkg) => {
-  const pkgIndex = selectedPackageNames.value.indexOf(pkg.name)
+const togglePackageSelected = (pkgName) => {
+  const pkgIndex = selectedPackageNames.value.indexOf(pkgName)
   if (pkgIndex > -1) {
     // Remove element as computed array is readonly
     selectedPackageNames.value.splice(pkgIndex, 1)
   } else {
-    selectedPackageNames.value.push(pkg.name)
+    selectedPackageNames.value.push(pkgName)
   }
 
   compare.value = [...new Set(selectedPackageNames.value)].sort().slice(0, 10).join(',')

--- a/app/src/views/Packages.vue
+++ b/app/src/views/Packages.vue
@@ -135,7 +135,8 @@ const limit = ref(60)
 
 const compare = useRouteQuery('compare', '')
 // remove duplicates if the user enters packages in the url directly
-compare.value = [...new Set(compare.value.split(','))].slice(0, 10).join(',')
+const tmp = compare.value.split(',').filter(value => value.match(/^[a-zA-Z0-9][a-zA-Z0-9@:.+_-]+$/))
+compare.value = [...new Set(tmp)].sort().slice(0, 10).join(',')
 
 const selectedPackageNames = computed(() => {
   if (compare.value) {

--- a/app/src/views/Packages.vue
+++ b/app/src/views/Packages.vue
@@ -137,13 +137,10 @@ const limit = ref(60)
 const compare = useRouteQuery('compare', '')
 const selectedPackageNames = computed(() => compare.value.split(','))
 
-const selectedPackages = ref([])
-const { isFinished2, isFetching2, data2, error2 } = useFetchPackagesPopularity(selectedPackageNames)
-if (isFinished2) {
-  selectedPackages.value = data2
-}
+const { isFinished2, isFetching2, selectedPackages, error2 } = useFetchPackagesPopularity(selectedPackageNames)
 
-console.log('selectedPackages', selectedPackages)
+const isPackageSelected = (pkg) => selectedPackages.value.map(selectedPackage => selectedPackage.name).includes(pkg.name)
+
 const togglePackageSelected = (pkg) => {
   if (selectedPackages.value.length > 0) {
     if (isPackageSelected(pkg)) {
@@ -159,7 +156,6 @@ const togglePackageSelected = (pkg) => {
   }
 }
 
-const isPackageSelected = (pkg) => selectedPackages.value.map(selectedPackage => selectedPackage.name).includes(pkg.name)
 
 const { isFinished, isFetching, data, error } = useFetchPackageList(query, offset, limit)
 

--- a/app/src/views/Packages.vue
+++ b/app/src/views/Packages.vue
@@ -134,7 +134,15 @@ const offset = ref(0)
 const limit = ref(60)
 
 const compare = useRouteQuery('compare', '')
-const selectedPackageNames = computed(() => compare.value ? compare.value.split(',') : [])
+// remove duplicates if the user enters packages in the url directly
+compare.value = [...new Set(compare.value.split(','))].slice(0, 10).join(',')
+
+const selectedPackageNames = computed(() => {
+  if (compare.value) {
+    return [...new Set(compare.value.split(','))].slice(0, 10)
+  }
+  return []
+})
 
 const { isFinished: isFinished2, isFetching: isFetching2, data: selectedPackages, error: error2 } = useFetchPackagesPopularity(selectedPackageNames)
 

--- a/app/tests/e2e/cypress/e2e/Compare.cy.js
+++ b/app/tests/e2e/cypress/e2e/Compare.cy.js
@@ -32,4 +32,11 @@ describe('Compare', () => {
       expect(loc.hash).to.eq('#packages=bash,linux')
     })
   })
+
+  it('generates the correct "edit selection" link', () => {
+    cy.visit('/compare/packages#packages=nano,vim,nano')
+    cy.wait('@api-packages-series')
+
+    cy.get('[data-test-id="edit-selection-cta"]').should('have.attr', 'href', '/packages?compare=nano,vim')
+  })
 })

--- a/justfile
+++ b/justfile
@@ -11,9 +11,11 @@ PHP-RUN := COMPOSE-RUN + ' --no-deps api'
 NODE-RUN := COMPOSE-RUN + ' --no-deps app'
 MARIADB-RUN := COMPOSE-RUN + ' -T --no-deps mariadb'
 
+# default command run when entering "just" only
 default:
 	just --list
 
+# load fixture data and startup all services defined in docker/app.yml
 init: start
 	{{PHP-DB-RUN}} bin/console cache:warmup
 	{{PHP-DB-RUN}} bin/console doctrine:database:drop --force --if-exists
@@ -23,15 +25,18 @@ init: start
 	{{PHP-DB-RUN}} bin/console doctrine:migrations:version --add --all --no-interaction
 	{{PHP-DB-RUN}} php -dmemory_limit=-1 bin/console doctrine:fixtures:load -n
 
+# start all services defined in docker/app.yml
 start:
 	{{COMPOSE}} up -d
 	{{MARIADB-RUN}} mariadb-admin -uroot -hmariadb --skip-ssl --wait=10 ping
 	@echo URL: http://localhost:${PORT}
 
+# start mariadb service defined in docker/app.yml
 start-db:
 	{{COMPOSE}} up -d mariadb
 	{{MARIADB-RUN}} mariadb-admin -uroot -hmariadb --skip-ssl --wait=10 ping
 
+# stop all services defined in docker/app.yml
 stop:
 	{{COMPOSE}} stop
 
@@ -43,65 +48,85 @@ import-db-dump file name='pkgstats_archlinux_de': start
 	{{PHP-DB-RUN}} bin/console doctrine:migrations:sync-metadata-storage --no-interaction
 	{{PHP-DB-RUN}} bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
 
+# remove containers and untracked files
 clean:
 	{{COMPOSE}} rm -vsf
 	git clean -fdqx -e .idea
 
+# remove containers & untracked files, rebuild all containers, install dependencies and run "just init"
 rebuild: clean
 	{{COMPOSE}} -f docker/cypress-run.yml -f docker/cypress-open.yml build --pull
 	just install
 	just init
 
+# install php & js dependencies
 install:
 	{{PHP-RUN}} composer --no-interaction install
 	{{NODE-RUN}} pnpm install --frozen-lockfile
 
+# short for "docker compose -f docker/app.yml -p {{args}}"
 compose *args:
 	{{COMPOSE}} {{args}}
 
+# short for "docker compose -f docker/app.yml -p run --rm {{args}}"
 compose-run *args:
 	{{COMPOSE-RUN}} {{args}}
 
+# short for "short for "docker compose -f docker/app.yml -p run --rm php {{args}}"
 php *args='-h':
 	{{PHP-RUN}} php {{args}}
 
+# run composer inside a php container
 composer *args:
 	{{PHP-RUN}} composer {{args}}
 
+# list outdated php dependencies
 composer-outdated: (composer "install") (composer "outdated --direct --strict")
 
+# list outdated js dependencies
 pnpm-outdated: (pnpm "install --frozen-lockfile") (pnpm "outdated")
 
+# list outdated dependencies
 outdated: composer-outdated pnpm-outdated
 
+# direct access to Sf console commands
 console *args:
 	{{PHP-RUN}} bin/console {{args}}
 
+# run phpunit inside a php container
 phpunit *args:
 	{{PHP-RUN}} vendor/bin/phpunit {{args}}
 
+# run phpstan inside a php containre
 phpstan *args:
 	{{PHP-RUN}} php -dmemory_limit=-1 vendor/bin/phpstan {{args}}
 
+# run node inside a node container
 node *args='-h':
 	{{NODE-RUN}} node {{args}}
 
+# run pnpm inside a php containre
 pnpm *args='-h':
 	{{NODE-RUN}} pnpm {{args}}
 
+# run jest inside a node containre
 jest *args:
 	{{NODE-RUN}} node_modules/.bin/jest --passWithNoTests {{args}}
 
+# run cypress-run command
 cypress *args:
 	{{COMPOSE}} -f docker/cypress-run.yml run --rm --no-deps --entrypoint cypress cypress-run {{args}}
 
+# run cypress tests in CLI
 cypress-run *args:
 	{{COMPOSE}} -f docker/cypress-run.yml run --rm --no-deps cypress-run --headless --browser chrome --project tests/e2e {{args}}
 
+# open cypress GUI to interactively run tests
 cypress-open *args:
 	Xephyr :${PORT} -screen 1920x1080 -resizeable -name Cypress -title "Cypress - {{ env_var('PROJECT_NAME') }}" -terminate -no-host-grab -extension MIT-SHM -extension XTEST -nolisten tcp &
 	DISPLAY=:${PORT} DISPLAY_SOCKET=/tmp/.X11-unix/X${PORT%%:*} {{COMPOSE}} -f docker/cypress-open.yml run --rm --no-deps cypress-open --project tests/e2e --e2e {{args}}
 
+# execute all php tests (validate composer, linting, phpunit)
 test-php:
 	{{PHP-RUN}} composer validate
 	{{PHP-RUN}} vendor/bin/phpcs
@@ -111,14 +136,17 @@ test-php:
 	{{PHP-RUN}} php -dmemory_limit=-1 vendor/bin/phpstan analyse
 	{{PHP-RUN}} vendor/bin/phpunit
 
+# execute all js tests (linting, jest, build project)
 test-js:
 	{{NODE-RUN}} node_modules/.bin/eslint '*.js' src tests --ext js --ext vue
 	{{NODE-RUN}} node_modules/.bin/stylelint 'src/assets/css/**/*.scss' 'src/assets/css/**/*.css' 'src/**/*.vue'
 	{{NODE-RUN}} node_modules/.bin/jest --passWithNoTests
 	{{NODE-RUN}} pnpm run build --output-path $(mktemp -d)
 
+# run all tests
 test: test-php test-js
 
+# run e2e tests
 test-e2e:
 	#!/usr/bin/env bash
 	set -e
@@ -131,27 +159,34 @@ test-e2e:
 		just cypress-run
 	fi
 
+# run database tests
 test-db *args: start-db
 	{{PHP-DB-RUN}} vendor/bin/phpunit -c phpunit-db.xml {{args}}
 
+# test db migrations
 test-db-migrations *args: start-db
 	{{PHP-DB-RUN}} vendor/bin/phpunit -c phpunit-db.xml --testsuite 'Doctrine Migrations Test' {{args}}
 
+# use jest and phpunit to generate code coverage reports
 test-coverage:
 	{{NODE-RUN}} node_modules/.bin/jest --passWithNoTests --coverage --coverageDirectory var/coverage/jest
 	{{PHP-RUN}} php -d zend_extension=xdebug -d xdebug.mode=coverage -d memory_limit=-1 vendor/bin/phpunit --coverage-html var/coverage/phpunit
 
+# run phpunit to generate db code coverage report
 test-db-coverage: start-db
 	{{PHP-RUN}} php -d zend_extension=xdebug -d xdebug.mode=coverage -d memory_limit=-1 vendor/bin/phpunit --coverage-html var/coverage -c phpunit-db.xml
 
+# run composer and pnpm audit commands
 test-security: (composer "audit")
 	{{NODE-RUN}} pnpm audit --prod
 
+# run phpcbf, eslint and stylelint to fix cs
 fix-code-style:
 	{{PHP-RUN}} vendor/bin/phpcbf || true
 	{{NODE-RUN}} node_modules/.bin/eslint '*.js' src tests --ext js --ext vue --fix
 	{{NODE-RUN}} node_modules/.bin/stylelint --fix 'src/assets/css/**/*.scss' 'src/assets/css/**/*.css' 'src/**/*.vue'
 
+# update all project dependencies
 update:
 	{{PHP-RUN}} composer --no-interaction update
 	{{PHP-RUN}} composer --no-interaction update --lock --no-scripts


### PR DESCRIPTION
In order to improve the UX when comparing packages, the info of selected packages has to be preserved when navigating back from /compare to /packages

Todo:
- [x] back button at Compare view
- [x] tests