### PR TITLE
Add kitty to fun statistics Terminal Emulators category

### DIFF
--- a/app/src/config/fun.json
+++ b/app/src/config/fun.json
@@ -93,6 +93,7 @@
     "alacritty",
     "gnome-console",
     "gnome-terminal",
+    "kitty",
     "konsole",
     "terminator",
     "xfce4-terminal",


### PR DESCRIPTION
# What

Add [Kitty](https://sw.kovidgoyal.net/kitty/) to fun statistics _Terminal Emulators_ category.

# Why

Kitty is the third popular terminal emulator at the time of rasing this PR.

# Testing

![image](https://github.com/user-attachments/assets/7de9d1dd-8a5a-4beb-9fd6-eb7f5d2ff445)