### PR TITLE
Add more terminal emulators

### DIFF
--- a/app/src/config/fun.json
+++ b/app/src/config/fun.json
@@ -105,9 +105,9 @@
     "rio",
     "rxvt-unicode",
     "terminator",
+    "wezterm",
     "xfce4-terminal",
     "xterm",
-    "wezterm",
     "yakuake"
   ],
   "Xorg GPU Drivers": [

--- a/app/src/config/fun.json
+++ b/app/src/config/fun.json
@@ -94,13 +94,20 @@
   ],
   "Terminal Emulators": [
     "alacritty",
+    "contour",
+    "foot",
     "gnome-console",
     "gnome-terminal",
     "kitty",
     "konsole",
+    "lxterminal",
+    "mate-terminal",
+    "rio",
+    "rxvt-unicode",
     "terminator",
     "xfce4-terminal",
     "xterm",
+    "wezterm",
     "yakuake"
   ],
   "Xorg GPU Drivers": [


### PR DESCRIPTION
Adds a few more terminal emulators to the stats. Default terminals for LXDE, Mate and other common mentioned terminals on the wild.