### PR TITLE
fun: add Helium Browser

### DIFF
--- a/app/src/config/fun.json
+++ b/app/src/config/fun.json
@@ -11,6 +11,7 @@
     "firefox",
     "firefox-developer-edition",
     "google-chrome",
+    "helium-browser-bin",
     "konqueror",
     "links",
     "lynx",


### PR DESCRIPTION
Adds the Helium Browser (`helium-browser-bin`) to the list of browsers.
