### PR TITLE
fun: rename some DE packages and add more DE packages

### DIFF
--- a/app/src/config/fun.json
+++ b/app/src/config/fun.json
@@ -54,12 +54,18 @@
   "Desktop Environments": [
     "budgie-desktop",
     "cinnamon",
-    "gnome-shell",
-    "lxde-common",
-    "mate-panel",
-    "plasma-workspace",
     "cosmic-session",
-    "xfdesktop"
+    "cutefish-core",
+    "deepin-session",
+    "enlightenment",
+    "gnome-session",
+    "lxde-common",
+    "lxqt-session",
+    "mate-session-manage",
+    "plasma-workspace",
+    "sugar",
+    "ukui-session-manager",
+    "xfce4-session"
   ],
   "File Managers": [
     "caja",


### PR DESCRIPTION
Some improvements to the fun statistics on Desktop Environments:

- I sorted them alphabetically.
- I renamed `gnome-shell` to `gnome-session`, `mate-panel` to `mate-session-manager` and `xfdesktop` to `xfce4-session`, as these packages are the ones that have the `{wayland-sessions,xsessions}/*.desktop` and the binaries responsible for running the DE (i.e., those who run these DEs definitely have these packages installed) and are consistent with the other packages.
- I added the `cutefish-core`, `deepin-session`, `enlightenment`, `sugar` and `ukui-session-manager` packages, which are other DEs officially supported by Arch Linux. There are two DEs that I did not add: `pantheon`, which does not have an entry in pkgstats and `phosh`, which I did not include because it is a DE for mobile.

And I couldn't check and run the tests locally because I simply didn't know how xD. I'm not a programmer and I encountered several problems trying to run `just install` and `just test`.
