### PR TITLE
fun: add three new categories for fun statistics

### DIFF
--- a/app/src/config/fun.json
+++ b/app/src/config/fun.json
@@ -200,5 +200,11 @@
     "utox",
     "weechat",
     "wire-desktop"
+  ],
+  "Widget Toolkits": [
+    "gtk3",
+    "gtk4",
+    "qt5-base",
+    "qt6-base"
   ]
 }


### PR DESCRIPTION
Three new categories for the fun statistics:

- Linux Kernels (`linux`, `linux-lts`, `linux-zen`, etc.)
- Graphics Drivers (`mesa`, `nvidia`, `vulkan-intel`, etc.)
- Widget Toolkits (`gtk3`, `qt6`, etc.)

The list of packages is pretty basic, considering that there are a [LOT of widget toolkits](https://en.wikipedia.org/wiki/List_of_widget_toolkits). But it's a good start for future contributions.

I didn't know where to place these three new categories, as the rest of the other categories are not in alphabetical order, so I tried to put them in alphabetical order somehow.

And again, I couldn't test it locally because I couldn't run `just install`.

Closes: https://github.com/archlinux-de/pkgstats.archlinux.de/issues/204
