### PR TITLE
Clarify popularity measurements

### DIFF
--- a/internal/apidoc/spec.go
+++ b/internal/apidoc/spec.go
@@ -54,17 +54,18 @@ type Response struct {
 }
 
 type Schema struct {
-	Ref        string             `json:"$ref,omitempty"`
-	Type       string             `json:"type,omitempty"`
-	Format     string             `json:"format,omitempty"`
-	Default    any                `json:"default,omitempty"`
-	Minimum    *int               `json:"minimum,omitempty"`
-	Maximum    *int               `json:"maximum,omitempty"`
-	MaxLength  *int               `json:"maxLength,omitempty"`
-	Nullable   bool               `json:"nullable,omitempty"`
-	Required   []string           `json:"required,omitempty"`
-	Properties map[string]*Schema `json:"properties,omitempty"`
-	Items      *Schema            `json:"items,omitempty"`
+	Description string             `json:"description,omitempty"`
+	Ref         string             `json:"$ref,omitempty"`
+	Type        string             `json:"type,omitempty"`
+	Format      string             `json:"format,omitempty"`
+	Default     any                `json:"default,omitempty"`
+	Minimum     *int               `json:"minimum,omitempty"`
+	Maximum     *int               `json:"maximum,omitempty"`
+	MaxLength   *int               `json:"maxLength,omitempty"`
+	Nullable    bool               `json:"nullable,omitempty"`
+	Required    []string           `json:"required,omitempty"`
+	Properties  map[string]*Schema `json:"properties,omitempty"`
+	Items       *Schema            `json:"items,omitempty"`
 }
 
 type SpecComponents struct {
@@ -80,6 +81,7 @@ type entitySpec struct {
 	listSchemaName  string
 	identifierField string
 	collectionField string
+	packages        bool
 	internal        bool
 }
 
@@ -94,6 +96,7 @@ var popularityEntities = []entitySpec{
 		listSchemaName:  "PackagePopularityList",
 		identifierField: "name",
 		collectionField: "packagePopularities",
+		packages:        true,
 	},
 	{
 		basePath:        "/api/countries",
@@ -187,35 +190,44 @@ var (
 )
 
 //nolint:goconst
-func popularityItemSchema(identifierField string) *Schema {
+func popularityItemSchema(identifierField, identifierDescription string, packages bool) *Schema {
+	countDescription := "Number of reports in the selected period that record this value."
+	samplesDescription := "Number of reports in the selected period with a recorded value for this metric."
+	if packages {
+		countDescription = "Number of reports in the selected period that include the package."
+		samplesDescription = "Estimated number of reports in the selected period."
+	}
+
 	return &Schema{
 		Type:     "object",
 		Required: []string{identifierField, "samples", "count", "popularity", "startMonth", "endMonth"},
 		Properties: map[string]*Schema{
-			identifierField: {Type: "string"},
-			"samples":       {Type: "integer"},
-			"count":         {Type: "integer"},
-			"popularity":    {Type: "number", Format: "float"},
-			"startMonth":    {Type: "integer"},
-			"endMonth":      {Type: "integer"},
+			identifierField: {Type: "string", Description: identifierDescription},
+			"samples":       {Type: "integer", Description: samplesDescription},
+			"count":         {Type: "integer", Description: countDescription},
+			"popularity":    {Type: "number", Format: "float", Description: "Percentage calculated as count / samples × 100, rounded to two decimal places."},
+			"startMonth":    {Type: "integer", Description: "First month included, in YYYYMM format."},
+			"endMonth":      {Type: "integer", Description: "Last month included, in YYYYMM format."},
 		},
 	}
 }
 
+//nolint:goconst
 func popularityListSchema(collectionField, itemSchemaRef string) *Schema {
 	return &Schema{
 		Type:     "object",
 		Required: []string{collectionField, "total", "count", "limit", "offset"},
 		Properties: map[string]*Schema{
 			collectionField: {
-				Type:  "array",
-				Items: &Schema{Ref: itemSchemaRef},
+				Type:        "array",
+				Description: "Matching popularity records.",
+				Items:       &Schema{Ref: itemSchemaRef},
 			},
-			"total":  {Type: "integer"},
-			"count":  {Type: "integer"},
-			"limit":  {Type: "integer"},
-			"offset": {Type: "integer"},
-			"query":  {Type: "string", Nullable: true},
+			"total":  {Type: "integer", Description: "Total number of matching records."},
+			"count":  {Type: "integer", Description: "Number of records returned."},
+			"limit":  {Type: "integer", Description: "Maximum number of records requested."},
+			"offset": {Type: "integer", Description: "Number of records skipped."},
+			"query":  {Type: "string", Nullable: true, Description: "Applied name filter, or null when not supplied."},
 		},
 	}
 }
@@ -253,7 +265,7 @@ func BuildSpec(includeInternal bool) *OpenAPISpec {
 		spec.Tags = append(spec.Tags, SpecTag{Name: e.tag})
 
 		itemSchemaRef := "#/components/schemas/" + e.itemSchemaName
-		spec.Components.Schemas[e.itemSchemaName] = popularityItemSchema(e.identifierField)
+		spec.Components.Schemas[e.itemSchemaName] = popularityItemSchema(e.identifierField, e.pathParamDesc, e.packages)
 		spec.Components.Schemas[e.listSchemaName] = popularityListSchema(e.collectionField, itemSchemaRef)
 
 		pathParam := Parameter{

--- a/internal/apidoc/spec_test.go
+++ b/internal/apidoc/spec_test.go
@@ -1,0 +1,34 @@
+package apidoc
+
+import "testing"
+
+func TestPopularitySchemaDescriptions(t *testing.T) {
+	spec := BuildSpec(true)
+
+	tests := []struct {
+		schema      string
+		field       string
+		description string
+	}{
+		{"PackagePopularity", "count", "Number of reports in the selected period that include the package."},
+		{"PackagePopularity", "samples", "Estimated number of reports in the selected period."},
+		{"CountryPopularity", "count", "Number of reports in the selected period that record this value."},
+		{"CountryPopularity", "samples", "Number of reports in the selected period with a recorded value for this metric."},
+		{"PackagePopularity", "popularity", "Percentage calculated as count / samples × 100, rounded to two decimal places."},
+		{"PackagePopularityList", "packagePopularities", "Matching popularity records."},
+		{"PackagePopularityList", "total", "Total number of matching records."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.schema+"_"+tt.field, func(t *testing.T) {
+			schema := spec.Components.Schemas[tt.schema]
+			if schema == nil {
+				t.Fatalf("schema %q not found", tt.schema)
+			}
+
+			if got := schema.Properties[tt.field].Description; got != tt.description {
+				t.Errorf("description = %q, want %q", got, tt.description)
+			}
+		})
+	}
+}

--- a/internal/sitemap/handler.go
+++ b/internal/sitemap/handler.go
@@ -54,6 +54,7 @@ func (h *Handler) HandleSitemap(w http.ResponseWriter, r *http.Request) {
 	urls := []URL{
 		{Loc: baseURL + "/", LastMod: lastMod},
 		{Loc: baseURL + "/getting-started"},
+		{Loc: baseURL + "/methodology"},
 		{Loc: baseURL + "/countries", LastMod: lastMod},
 		{Loc: baseURL + "/packages", LastMod: lastMod},
 		{Loc: baseURL + "/compare/system-architectures/current", LastMod: lastMod},

--- a/internal/sitemap/handler_test.go
+++ b/internal/sitemap/handler_test.go
@@ -80,6 +80,7 @@ func TestHandleSitemap(t *testing.T) {
 
 	for _, path := range []string{
 		"http://example.com/",
+		"http://example.com/methodology",
 		"http://example.com/packages",
 		"http://example.com/countries",
 		"http://example.com/countries/de",

--- a/internal/ui/apidoc/handler_test.go
+++ b/internal/ui/apidoc/handler_test.go
@@ -1,0 +1,58 @@
+package apidoc
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"pkgstatsd/internal/apidoc"
+	"pkgstatsd/internal/ui/layout"
+)
+
+func TestHandleAPIDocRendersSchemaDescriptions(t *testing.T) {
+	handler := NewHandler(&layout.Manifest{}, apidoc.BuildSpec(false))
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/doc", nil)
+
+	handler.HandleAPIDoc(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	body := rr.Body.String()
+	for _, text := range []string{
+		`href="/methodology"`,
+		"Description",
+		"Estimated number of reports in the selected period.",
+		"Percentage calculated as count / samples × 100, rounded to two decimal places.",
+	} {
+		if !strings.Contains(body, text) {
+			t.Errorf("response does not contain %q", text)
+		}
+	}
+}
+
+func TestRenderSchemaDetailIncludesArrayItems(t *testing.T) {
+	spec := apidoc.BuildSpec(false)
+	var body strings.Builder
+	err := renderSchemaDetail(
+		&apidoc.Schema{Ref: "#/components/schemas/PackagePopularityList"},
+		spec.Components,
+	).Render(context.Background(), &body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, text := range []string{
+		"Matching popularity records.",
+		"PackagePopularity",
+		"Estimated number of reports in the selected period.",
+	} {
+		if !strings.Contains(body.String(), text) {
+			t.Errorf("response does not contain %q", text)
+		}
+	}
+}

--- a/internal/ui/apidoc/templates.templ
+++ b/internal/ui/apidoc/templates.templ
@@ -14,6 +14,7 @@ templ APIDocContent(spec *apidoc.OpenAPISpec) {
 	<p class="mb-4">
 		The pkgstats API provides read-only access to package popularity data.
 		The <a href="/getting-started">pkgstats CLI</a> uses this API to search and compare packages from the terminal.
+		See <a href="/methodology">how popularity is measured</a>.
 		Please be considerate with request rates to keep the service available for everyone.
 	</p>
 	for _, tag := range spec.Tags {
@@ -237,6 +238,11 @@ templ renderSchemaDetail(s *apidoc.Schema, components apidoc.SpecComponents) {
 			}
 			if resolved.Properties != nil {
 				@renderSchemaProperties(resolved)
+				for _, property := range resolved.Properties {
+					if property.Items != nil && property.Items.Ref != "" {
+						@renderSchemaDetail(property.Items, components)
+					}
+				}
 			}
 		}
 	}
@@ -249,6 +255,7 @@ templ renderSchemaProperties(s *apidoc.Schema) {
 				<tr>
 					<th>Field</th>
 					<th>Type</th>
+					<th>Description</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -261,6 +268,7 @@ templ renderSchemaProperties(s *apidoc.Schema) {
 							}
 						</td>
 						<td><code>{ schemaTypeString(s.Properties[name]) }</code></td>
+						<td>{ s.Properties[name].Description }</td>
 					</tr>
 				}
 			</tbody>

--- a/internal/ui/compare/templates.templ
+++ b/internal/ui/compare/templates.templ
@@ -3,6 +3,7 @@ package compare
 import (
 	"fmt"
 	"pkgstatsd/internal/chartdata"
+	"pkgstatsd/internal/ui/components"
 	"pkgstatsd/internal/ui/layout"
 	"strings"
 )
@@ -21,6 +22,7 @@ templ CompareContent(names []string, excessNames []string, data chartdata.Data) 
 	<popularity-chart role="img" aria-label={ "Chart comparing popularity of " + strings.Join(names, ", ") + " over time" }>
 		@templ.JSONScript("", data)
 	</popularity-chart>
+	@components.PackagePopularityExplanation()
 	<div class="mt-3">
 		<a class="btn btn-primary" rel="nofollow" href={ templ.SafeURL("/packages?compare=" + allNames(names, excessNames)) }>Edit selection</a>
 	</div>

--- a/internal/ui/components/popularity.templ
+++ b/internal/ui/components/popularity.templ
@@ -2,14 +2,28 @@ package components
 
 import "fmt"
 
+templ PackagePopularityExplanation() {
+	<p class="small text-body-secondary mt-3 mb-0">
+		Popularity is the percentage of pkgstats reports in the selected period that include a package.
+		<a href="/methodology">How popularity is measured</a>.
+	</p>
+}
+
+templ ValuePopularityExplanation() {
+	<p class="small text-body-secondary mt-3 mb-0">
+		Popularity is the percentage of pkgstats reports in the selected period that report each value.
+		<a href="/methodology">How popularity is measured</a>.
+	</p>
+}
+
 templ PopularityBar(popularity float64) {
-	<div class="progress bg-transparent progress-large" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow={ fmt.Sprintf("%.2f", popularity) } title={ fmt.Sprintf("%.2f%%", popularity) }>
+	<div class="progress bg-transparent progress-large" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow={ fmt.Sprintf("%.2f", popularity) } title={ fmt.Sprintf("%.2f", popularity) }>
 		<div
 			class="progress-bar"
 			style={ fmt.Sprintf("width: %.2f%%", popularity) }
 		>
 			if popularity > 5 {
-				{ fmt.Sprintf("%.2f%%", popularity) }
+				{ fmt.Sprintf("%.2f", popularity) }
 			}
 		</div>
 	</div>

--- a/internal/ui/country/templates.templ
+++ b/internal/ui/country/templates.templ
@@ -3,6 +3,7 @@ package country
 import (
 	"pkgstatsd/internal/chartdata"
 	"pkgstatsd/internal/countries"
+	"pkgstatsd/internal/ui/components"
 	"strings"
 )
 
@@ -12,6 +13,7 @@ templ CountriesContent(countryPopularities []countries.CountryPopularity) {
 	<country-map role="img" aria-label="World map showing distribution of submitted package statistics by country">
 		@templ.JSONScript("", toSvgMapValues(countryPopularities))
 	</country-map>
+	@components.ValuePopularityExplanation()
 }
 
 type popularityValue struct {
@@ -29,10 +31,10 @@ func toSvgMapValues(pops []countries.CountryPopularity) map[string]popularityVal
 
 templ CountryDetailContent(code string, data chartdata.Data) {
 	<h1 class="mb-3">{ code }</h1>
-	<p class="mb-3">Relative usage from <strong>{ code }</strong></p>
 	<popularity-chart role="img" aria-label={ "Chart showing popularity of Arch Linux in " + code + " over time" }>
 		@templ.JSONScript("", data)
 	</popularity-chart>
+	@components.ValuePopularityExplanation()
 	<div class="mt-3">
 		<a class="btn btn-outline-primary" href="/countries">All countries</a>
 	</div>

--- a/internal/ui/fundetail/templates.templ
+++ b/internal/ui/fundetail/templates.templ
@@ -25,6 +25,7 @@ templ FunDetailCurrentContent(category string, topPkgs []packages.PackagePopular
 		</p>
 	}
 	@funCompareLink(compareURL)
+	@components.PackagePopularityExplanation()
 }
 
 templ FunDetailHistoryContent(category string, data chartdata.Data, compareURL string) {
@@ -34,6 +35,7 @@ templ FunDetailHistoryContent(category string, data chartdata.Data, compareURL s
 		@templ.JSONScript("", data)
 	</popularity-chart>
 	@funCompareLink(compareURL)
+	@components.PackagePopularityExplanation()
 }
 
 templ funCompareLink(compareURL string) {
@@ -57,7 +59,7 @@ templ funPackageTable(pkgs []packages.PackagePopularity) {
 		<thead>
 			<tr>
 				<th scope="col">Package</th>
-				<th scope="col">Popularity</th>
+				<th scope="col">Popularity (%)</th>
 			</tr>
 		</thead>
 		<tbody>

--- a/internal/ui/home/templates.templ
+++ b/internal/ui/home/templates.templ
@@ -66,6 +66,7 @@ templ HomeContent() {
 			<h2 class="h4">Documentation</h2>
 			<ul class="ps-4">
 				<li><a href="/getting-started">Getting started</a></li>
+				<li><a href="/methodology">How popularity is measured</a></li>
 				<li><a href="https://wiki.archlinux.org/index.php/Pkgstats" rel="nofollow">Arch Linux Wiki</a></li>
 				<li><a href="/api/doc">API documentation</a></li>
 			</ul>

--- a/internal/ui/methodology/handler.go
+++ b/internal/ui/methodology/handler.go
@@ -1,0 +1,26 @@
+package methodology
+
+import (
+	"net/http"
+
+	"pkgstatsd/internal/ui/layout"
+)
+
+type Handler struct {
+	manifest *layout.Manifest
+}
+
+func NewHandler(manifest *layout.Manifest) *Handler {
+	return &Handler{manifest: manifest}
+}
+
+func (h *Handler) HandleMethodology(w http.ResponseWriter, r *http.Request) {
+	layout.Render(w, r,
+		layout.Page{Title: "How popularity is measured", Description: "How pkgstats calculates package and system popularity statistics.", Path: "/methodology", Manifest: h.manifest, CanonicalPath: "/methodology"},
+		MethodologyContent(),
+	)
+}
+
+func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /methodology", h.HandleMethodology)
+}

--- a/internal/ui/methodology/templates.templ
+++ b/internal/ui/methodology/templates.templ
@@ -44,6 +44,15 @@ templ MethodologyContent() {
 				occasionally fail. These cases are uncommon; the percentage uses reports with a recorded value for the
 				relevant metric.
 			</p>
+			<h2 class="h4 mt-4">Examples</h2>
+			<p>
+				If a month has an estimated 10,000 reports and 1,250 include <code>firefox</code>, its popularity is
+				<code>1,250 / 10,000 × 100 = 12.5%</code>.
+			</p>
+			<p>
+				If 1,800 of 10,000 recorded country values are Germany, Germany's popularity is
+				<code>1,800 / 10,000 × 100 = 18%</code>.
+			</p>
 			<h2 class="h4 mt-4">Time ranges</h2>
 			<p>
 				For periods spanning multiple months, pkgstats combines each month's counts and totals before calculating the

--- a/internal/ui/methodology/templates.templ
+++ b/internal/ui/methodology/templates.templ
@@ -1,0 +1,54 @@
+package methodology
+
+templ MethodologyContent() {
+	<div class="row">
+		<div class="col-12 col-lg-8">
+			<h1 class="mb-3">How popularity is measured</h1>
+			<p class="mb-4">
+				pkgstats collects anonymous reports and groups them by month. Popularity is shown as a percentage and is
+				calculated from reports received during the selected period.
+			</p>
+			<div class="table-responsive">
+				<table class="table table-sm">
+					<thead>
+						<tr>
+							<th scope="col">Statistic</th>
+							<th scope="col">What is counted</th>
+							<th scope="col">Percentage calculation</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<th scope="row">Packages</th>
+							<td>Reports that include the package</td>
+							<td>Package count divided by the monthly report total</td>
+						</tr>
+						<tr>
+							<th scope="row">Other statistics</th>
+							<td>One recorded value per report</td>
+							<td>Value count divided by all recorded values for the metric</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+			<h2 class="h4 mt-4">Packages</h2>
+			<p>
+				A report can include many packages, so summing package counts would count each report more than once. To
+				estimate the number of reports for a month, pkgstats uses the count of that month's most frequently reported
+				package.
+			</p>
+			<h2 class="h4 mt-4">Other statistics</h2>
+			<p>
+				Countries, mirrors, system architectures, operating-system architectures, and operating-system IDs each
+				record at most one value per report. Some older clients omit optional values, and country lookup can
+				occasionally fail. These cases are uncommon; the percentage uses reports with a recorded value for the
+				relevant metric.
+			</p>
+			<h2 class="h4 mt-4">Time ranges</h2>
+			<p>
+				For periods spanning multiple months, pkgstats combines each month's counts and totals before calculating the
+				percentage. Values are rounded to two decimal places.
+			</p>
+		</div>
+	</div>
+}

--- a/internal/ui/operatingsystems/templates.templ
+++ b/internal/ui/operatingsystems/templates.templ
@@ -1,11 +1,14 @@
 package operatingsystems
 
-import "pkgstatsd/internal/chartdata"
+import (
+	"pkgstatsd/internal/chartdata"
+	"pkgstatsd/internal/ui/components"
+)
 
 templ CompareContent(data chartdata.Data) {
 	<h1 class="mb-3">Compare Operating Systems</h1>
-	<p class="mb-3">Relative usage of operating system distributions</p>
 	<popularity-chart role="img" aria-label="Chart showing relative usage of operating system distributions over time">
 		@templ.JSONScript("", data)
 	</popularity-chart>
+	@components.ValuePopularityExplanation()
 }

--- a/internal/ui/packagedetail/templates.templ
+++ b/internal/ui/packagedetail/templates.templ
@@ -1,11 +1,14 @@
 package packagedetail
 
-import "pkgstatsd/internal/chartdata"
+import (
+	"pkgstatsd/internal/chartdata"
+	"pkgstatsd/internal/ui/components"
+)
 
 templ PackageDetailContent(name string, data chartdata.Data) {
 	<h1 class="mb-3">{ name }</h1>
-	<p class="mb-3">Relative usage of <strong>{ name }</strong></p>
 	<popularity-chart role="img" aria-label={ "Chart showing popularity of " + name + " over time" }>
 		@templ.JSONScript("", data)
 	</popularity-chart>
+	@components.PackagePopularityExplanation()
 }

--- a/internal/ui/packagelist/templates.templ
+++ b/internal/ui/packagelist/templates.templ
@@ -77,6 +77,7 @@ templ PackagesContent(list *packages.PackagePopularityList, query string, curren
 			No packages found matching "{ query }"
 		</div>
 	}
+	@components.PackagePopularityExplanation()
 }
 
 templ CompareTable(pkgs []packages.PackagePopularity, query string, offset int, limit int, compare string) {
@@ -84,7 +85,7 @@ templ CompareTable(pkgs []packages.PackagePopularity, query string, offset int, 
 		<thead>
 			<tr>
 				<th scope="col">Package</th>
-				<th scope="col">Popularity</th>
+				<th scope="col">Popularity (%)</th>
 				<th scope="col" class="d-none d-lg-table-cell text-end">Compare</th>
 			</tr>
 		</thead>
@@ -119,7 +120,7 @@ templ PackageTable(pkgs []packages.PackagePopularity, query string, offset int, 
 		<thead>
 			<tr>
 				<th scope="col">Package</th>
-				<th scope="col">Popularity</th>
+				<th scope="col">Popularity (%)</th>
 				<th scope="col" class="d-none d-lg-table-cell text-end">Compare</th>
 			</tr>
 		</thead>

--- a/internal/ui/routes.go
+++ b/internal/ui/routes.go
@@ -20,6 +20,7 @@ import (
 	"pkgstatsd/internal/ui/home"
 	"pkgstatsd/internal/ui/layout"
 	"pkgstatsd/internal/ui/legal"
+	"pkgstatsd/internal/ui/methodology"
 	uios "pkgstatsd/internal/ui/operatingsystems"
 	"pkgstatsd/internal/ui/packagedetail"
 	"pkgstatsd/internal/ui/packagelist"
@@ -53,6 +54,7 @@ func RegisterRoutes(
 	fundetail.NewHandler(pkgRepo, manifest).RegisterRoutes(mux)
 	apidoc.NewHandler(manifest, specpkg.BuildSpec(includeInternalAPIDocs)).RegisterRoutes(mux)
 	legal.NewHandler(manifest).RegisterRoutes(mux)
+	methodology.NewHandler(manifest).RegisterRoutes(mux)
 
 	handleAssets(mux, assets)
 	handleStatic(mux, static)

--- a/internal/ui/routes_test.go
+++ b/internal/ui/routes_test.go
@@ -4,9 +4,47 @@ import (
 	"io/fs"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"testing/fstest"
+
+	"pkgstatsd/internal/ui/layout"
 )
+
+func TestRegisterRoutes_Methodology(t *testing.T) {
+	manifest, err := layout.NewManifest([]byte(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	RegisterRoutes(
+		mux,
+		manifest,
+		nil, nil, nil, nil,
+		fstest.MapFS{"dist/assets/main.css": {Data: []byte("body {}")}},
+		fstest.MapFS{"static/archicon.svg": {Data: []byte("<svg/>")}},
+		fstest.MapFS{},
+		false,
+	)
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/methodology", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	body := rr.Body.String()
+	for _, text := range []string{
+		"<title>How popularity is measured</title>",
+		`rel="canonical" href="http://example.com/methodology"`,
+	} {
+		if !strings.Contains(body, text) {
+			t.Errorf("response does not contain %q", text)
+		}
+	}
+}
 
 func TestRootFiles(t *testing.T) {
 	root := fstest.MapFS{

--- a/internal/ui/systemarchitectures/templates.templ
+++ b/internal/ui/systemarchitectures/templates.templ
@@ -7,11 +7,11 @@ import (
 
 templ CompareContent(presets []preset, activePreset string, data chartdata.Data) {
 	<h1 class="mb-3">Compare System Architectures</h1>
-	<p class="mb-3">Relative usage of system architectures</p>
 	@components.TabNav(presetTabs(presets, activePreset))
 	<popularity-chart role="img" aria-label="Chart showing relative usage of system architectures over time">
 		@templ.JSONScript("", data)
 	</popularity-chart>
+	@components.ValuePopularityExplanation()
 }
 
 func presetTabs(presets []preset, activePreset string) []components.Tab {

--- a/src/components/country-map.ts
+++ b/src/components/country-map.ts
@@ -84,6 +84,11 @@ class CountryMap extends HTMLElement {
                         border: { color: gridColor },
                         grid: { color: gridColor },
                         ticks: { color: textColor },
+                        title: {
+                            display: true,
+                            text: "Popularity (%)",
+                            color: textColor,
+                        },
                     },
                     y: {
                         border: { color: gridColor },
@@ -125,8 +130,8 @@ class CountryMap extends HTMLElement {
             data: {
                 data: {
                     popularity: {
-                        name: "share",
-                        format: "{0}%",
+                        name: "Popularity (%)",
+                        format: "{0}",
                         thousandSeparator: ",",
                     },
                 },

--- a/src/components/popularity-chart.ts
+++ b/src/components/popularity-chart.ts
@@ -250,6 +250,11 @@ class PopularityChart extends HTMLElement {
                         border: { color: gridColor },
                         grid: { color: gridColor },
                         ticks: { color: textColor },
+                        title: {
+                            display: true,
+                            text: "Popularity (%)",
+                            color: textColor,
+                        },
                     },
                     y: {
                         border: { color: gridColor },
@@ -344,6 +349,11 @@ class PopularityChart extends HTMLElement {
                         border: { color: gridColor },
                         grid: { color: gridColor },
                         ticks: { color: textColor },
+                        title: {
+                            display: true,
+                            text: "Popularity (%)",
+                            color: textColor,
+                        },
                     },
                 },
                 elements: {


### PR DESCRIPTION
Fixes #223 by labeling popularity charts and the country map as percentages, adding contextual links to an explanation of the calculation, and documenting the corresponding API fields.